### PR TITLE
Update `kubectl` image for deployer to `1.27.5`

### DIFF
--- a/config/jobs/ci-infra/ci-infra-postsubmits.yaml
+++ b/config/jobs/ci-infra/ci-infra-postsubmits.yaml
@@ -27,7 +27,7 @@ postsubmits:
     spec:
       serviceAccountName: deployer
       containers:
-      - image: bitnami/kubectl:1.24.7
+      - image: bitnami/kubectl:1.27.5
         command:
         - config/prow/deploy.sh
         env:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Our prow clusters run on Kubernetes v1.27 now. Let's keep the `kubectl` version in sync. [1.27.5](https://hub.docker.com/r/bitnami/kubectl/tags?page=1&name=1.27) is the latest version available atm.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
